### PR TITLE
Added a link to gemcanary in 'Other Companies Using Rails'

### DIFF
--- a/source/_content.markdown
+++ b/source/_content.markdown
@@ -36,4 +36,5 @@ Roster](http://www.techroster.to/) and tag yourself with "rails".
 ### Other Companies Using Rails
 
 * [Add more companies here...](https://github.com/okgrow/railstoronto.com)
+* [gemcanary](https://gemcanary.com/)
 * [theScore](http://beta.thescore.com)


### PR DESCRIPTION
I wanted to add a link to [gemcanary](https://gemcanary.com), a Rails security product we made with lots of love in Toronto.

I added it to the "Other Companies Using Rails" list, but I realize how this can be an inappropriate place to put it. Please let me know what you think
