### PR TITLE
Update toronto ruby slack link to point to canonical one

### DIFF
--- a/source/_content.markdown
+++ b/source/_content.markdown
@@ -18,7 +18,7 @@ order please).
 
 * [+](https://github.com/okgrow/railstoronto.com)
 * [Add more events here...](https://github.com/okgrow/railstoronto.com)
-* [TorontoRB Slack group](http://slack.rubytoronto.com)
+* [Toronto Ruby Slack group](http://slack.torontoruby.org)
 
 ### Education
 


### PR DESCRIPTION
The Toronto Ruby Brigade slack group and Jasdeep Singh's slack group are
combining the slack groups, so this link should point to the canonical
one now.