### PR TITLE
Fix link for Universe

### DIFF
--- a/source/_content.markdown
+++ b/source/_content.markdown
@@ -80,7 +80,7 @@ order please).
 * [theScore](http://beta.thescore.com)
 * [Think Dirty](http://thinkdirtyapp.com)
 * [TouchBistro](http://touchbistro.com/)
-* [Uniiverse](https://www.uniiverse.com/)
+* [Universe](https://www.universe.com/)
 * [Uken Games](http://uken.com/)
 * [Wave Accounting](https://www.waveapps.com/)
 * [Wealthsimple](https://www.wealthsimple.com/)


### PR DESCRIPTION
Seems the company named change a while ago:

https://betakit.com/uniiverse-becomes-universe-opens-office-in-san-francisco/

The old site URL triggers a browser warning because the certificate has expired.